### PR TITLE
Removed depends_on

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,6 @@ services:
       interval: 10s
       timeout: 1s
 
-    depends_on:
-        redis:
-            condition: healthy
 networks:
   site:
     external: true


### PR DESCRIPTION
- Urgent! depends_on cannot be used to determine health of services defined outside the place where the inquiring service is defined! 